### PR TITLE
- Update `@types/node` to version `^22.14.0` in devDependencies

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -99,7 +99,7 @@
 
 <script type="module">
     // Import the library (in production, this would be from node_modules)
-    import GanttChart from '../src/gantt-chartmeleon.js';
+    import {GanttChart} from '../src/gantt-chartmeleon.js';
 
     // Initialize Gantt Chart
     const gantt = new GanttChart('#gantt-container', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bentipe/gantt-chartmeleon",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bentipe/gantt-chartmeleon",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "GPL-3.0",
       "dependencies": {
         "terser": "^5.43.1"
       },
       "devDependencies": {
-        "@types/node": "^20.10.0",
+        "@types/node": "^22.14.0",
         "eslint": "^8.55.0",
         "eslint-plugin-vue": "^9.27.0",
         "prettier": "^3.1.0",
@@ -950,10 +950,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
-      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.14.0",
     "eslint": "^8.55.0",
     "eslint-plugin-vue": "^9.27.0",
     "prettier": "^3.1.0",


### PR DESCRIPTION
- Update `package-lock.json` to reflect new `@types/node` version and minor version bump (`1.0.1`)
- Fix import syntax for GanttChart in demo HTML file